### PR TITLE
Add osx to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,19 @@
 language: cpp
 os:
   - linux
-    sudo: required
   - osx
 compiler:
   - gcc
   - clang
 before_install:
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then add-apt-repository -y ppa:kalakris/cmake; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:kalakris/cmake; fi
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:boost-latest/ppa; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then apt-get -qq -d update; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq -d update; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
 install:
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then apt-get -qq install libboost1.55-all-dev cmake g++-4.8; fi
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq install libboost1.55-all-dev cmake g++-4.8; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install homebrew/versions/gcc48; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install homebrew/versions/boost155; fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,22 @@
 ---
 language: cpp
+os:
+  - linux
+  - osx
 compiler:
-- gcc
-- clang
+  - gcc
+  - clang
 before_install:
 - sudo add-apt-repository -y ppa:kalakris/cmake
 - sudo add-apt-repository -y ppa:boost-latest/ppa
 - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 - sudo apt-get -qq -d update
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
 install:
-- sudo apt-get -qq install libboost1.55-all-dev cmake g++-4.8
-- sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then apt-get -qq install libboost1.55-all-dev cmake g++-4.8; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install homebrew/versions/gcc48; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install homebrew/versions/boost155; fi
 script:
 - bin/fetch-configlet
 - bin/configlet .

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,16 @@
 language: cpp
 os:
   - linux
+    sudo: required
   - osx
 compiler:
   - gcc
   - clang
 before_install:
-- sudo add-apt-repository -y ppa:kalakris/cmake
-- sudo add-apt-repository -y ppa:boost-latest/ppa
-- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-- sudo apt-get -qq -d update
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then add-apt-repository -y ppa:kalakris/cmake; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:boost-latest/ppa; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then add-apt-repository -y ppa:ubuntu-toolchain-r/test; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then apt-get -qq -d update; fi
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
 install:
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then apt-get -qq install libboost1.55-all-dev cmake g++-4.8; fi


### PR DESCRIPTION
The current instructions for setting up the C++ build environment on Mac OS X are:

`brew install boost`

This installs a newer version of Boost, and neglects to install gcc 4.8, which seems to be the supported version. Let's make add this configuration to CI and see if it works.
